### PR TITLE
Remove async from setup functions

### DIFF
--- a/Sources/SwiftyJSCore/JSIntepreter+Setup.swift
+++ b/Sources/SwiftyJSCore/JSIntepreter+Setup.swift
@@ -9,14 +9,14 @@ import Foundation
 import JavaScriptCore
 
 extension JSInterpreter {
-    func setupGlobal() async throws {
+    func setupGlobal() throws {
         _ = context.evaluateScript("""
                 var global = this;
                 var window = this;
             """)
     }
     
-    func setupConsole() async throws {
+    func setupConsole() throws {
         for method in ["log", "trace", "info", "warn", "error", "dir"] {
             let logger = logger
             let consoleFunc: @convention(block) () -> Void = {
@@ -28,7 +28,7 @@ extension JSInterpreter {
         }
     }
     
-    func setupExceptionHandler() async throws {
+    func setupExceptionHandler() throws {
         let logger = logger
         let handler: ((JSContext?, JSValue?) -> Void) = { context, exception in
             

--- a/Sources/SwiftyJSCore/JSInterpreter+Fetch.swift
+++ b/Sources/SwiftyJSCore/JSInterpreter+Fetch.swift
@@ -9,7 +9,7 @@ import Foundation
 import JavaScriptCore
 
 extension JSInterpreter {
-    func setupFetch() async throws {
+    func setupFetch() throws {
         let fetch = fetch
         let fetchFunc: @convention(block) () -> JSValue = {
             let args = JSContext.currentArguments()!

--- a/Sources/SwiftyJSCore/JSInterpreter.swift
+++ b/Sources/SwiftyJSCore/JSInterpreter.swift
@@ -19,10 +19,10 @@ public actor JSInterpreter {
         self.logger = logger
         self.fetch = fetch
         self.context = JSContext()
-        try await setupExceptionHandler()
-        try await setupGlobal()
-        try await setupConsole()
-        try await setupFetch()
+        try setupExceptionHandler()
+        try setupGlobal()
+        try setupConsole()
+        try setupFetch()
     }
 
     deinit {


### PR DESCRIPTION
I was surprised to find that the initializer for `JSInterpreter` is async. I investigated a bit, and it does make sense because it is calling actor-isolated methods. But, I also noticed that those functions that actually do not do any async work.

This doesn't have any externally-visible effects. But I thought it be might be worth changing. And since they are internal, this cannot affect the public API, so it does preserve the ability to change these in the future if it becomes necessary.