### PR TITLE
Enable strict concurrency checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,10 +20,12 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftyJSCore",
-            dependencies: []),
+            dependencies: [],
+			swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
         .testTarget(
             name: "SwiftyJSCoreTests",
             dependencies: ["SwiftyJSCore"],
-            resources: [.process("script.js")]),
+            resources: [.process("script.js")],
+			swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]),
     ]
 )


### PR DESCRIPTION
Turns on strict checking. This introduces 9 warnings with Xcode 15.3/Swift 5.10.

Will discuss more in #5 