### PR TITLE
add text() to fetch response

### DIFF
--- a/Sources/SwiftyJSCore/JSInterpreter+Fetch.swift
+++ b/Sources/SwiftyJSCore/JSInterpreter+Fetch.swift
@@ -102,6 +102,7 @@ private func update(request: inout URLRequest, with options: JSValue) {
     var url: String? { get }
     
     func json() -> JSValue
+    func text() -> JSValue
 }
 
 class JSFetchResponse: NSObject, JSFetchResponseProtocol, @unchecked Sendable {
@@ -148,6 +149,24 @@ class JSFetchResponse: NSObject, JSFetchResponseProtocol, @unchecked Sendable {
                 return
             }
             resolve?.call(withArguments: [json])
+        }
+    }
+
+    @objc func text() -> JSValue {
+        guard let context = context else {
+            return JSValue.init()
+        }
+        let data = data
+        return JSValue(newPromiseIn: context) { [weak context] resolve, reject in
+            guard let context = context else {
+                return
+            }
+            guard let textString = String(data: data, encoding: .utf8) else {
+                let exception = JSValue(newErrorFromMessage: "fetch: text() failed to decode data", in: context)!
+                reject?.call(withArguments: [exception])
+                return
+            }
+            resolve?.call(withArguments: [textString])
         }
     }
 }

--- a/Tests/SwiftyJSCoreTests/FetchTests.swift
+++ b/Tests/SwiftyJSCoreTests/FetchTests.swift
@@ -55,6 +55,14 @@ final class FetchTests: XCTestCase {
         XCTAssertEqual(lastRequest?.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
     
+    func testFetchText() async throws {
+        let text: String = try await interpreter.call(function: "testFetchText", arguments: [])
+        XCTAssertEqual(text, "{ \"id\": 123, \"name\": \"Foobar\" }")
+        let lastRequest = await TestRequest.shared.last
+        XCTAssertNotNil(lastRequest)
+        XCTAssertEqual(lastRequest?.httpMethod, "GET")
+    }
+
     func testFetchError() async throws {
         do {
             let _: String = try await interpreter.call(function: "testFetchMissingArguments", arguments: [])

--- a/Tests/SwiftyJSCoreTests/script.js
+++ b/Tests/SwiftyJSCoreTests/script.js
@@ -62,6 +62,17 @@ var testPOSTFetch = async () => {
     var json = await response.json();
     return json.name;
 }
+var testFetchText = async () => {
+    var response = await fetch("http://domain.net/test1.json");
+    if (response.status != 200) {
+        throw Error("Response status not 200")
+    }
+    if (!response.ok) {
+        throw Error("Response not OK")
+    }
+    var text = await response.text();
+    return text;
+}
 var testFetchMissingArguments = async () => {
     return await fetch();
 }


### PR DESCRIPTION
This PR adds `text()` to `JSFetchResponse`, next to the already-existing `json()`.