### PR TITLE
make console.debug() only log in DEBUG mode

### DIFF
--- a/Sources/SwiftyJSCore/JSIntepreter+Setup.swift
+++ b/Sources/SwiftyJSCore/JSIntepreter+Setup.swift
@@ -17,11 +17,17 @@ extension JSInterpreter {
     }
     
     func setupConsole() throws {
-        for method in ["log", "trace", "info", "warn", "error", "dir"] {
+        for method in ["log", "trace", "debug", "info", "warn", "error", "dir"] {
             let logger = logger
             let consoleFunc: @convention(block) () -> Void = {
-                let message = JSContext.currentArguments()!.map { "\($0)"}.joined()
+                let message = JSContext.currentArguments()!.map { "\($0)" }.joined()
+#if DEBUG
                 logger.log("\(method): \(message)")
+#else
+                if method != "debug" {
+                    logger.log("\(method): \(message)")
+                }
+#endif
             }
             let console = context.objectForKeyedSubscript("console")
             console?.setObject(unsafeBitCast(consoleFunc, to: AnyObject.self), forKeyedSubscript: method as NSString)

--- a/Tests/SwiftyJSCoreTests/SwiftyJSCoreTests.swift
+++ b/Tests/SwiftyJSCoreTests/SwiftyJSCoreTests.swift
@@ -115,7 +115,7 @@ final class SwiftyJSCoreTests: XCTestCase {
             XCTAssertEqual(name, "TypeError")
             XCTAssertEqual(message, "TestError")
             XCTAssert(!stack.isEmpty)
-            XCTAssert(stack == "@script.js:33:24\ntestException@script.js:32:28")
+            XCTAssert(stack == "@script.js:34:24\ntestException@script.js:33:28")
             return
         }
     }

--- a/Tests/SwiftyJSCoreTests/script.js
+++ b/Tests/SwiftyJSCoreTests/script.js
@@ -1,4 +1,5 @@
 console.log("JS loading")
+console.debug("Debug log")
 
 var testNoReturnValue = () => {
     console.log("testNoReturnValue called");


### PR DESCRIPTION
In release mode:

```
$ swift test -c release | grep ^JS:
JS: JSInterpreter init
JS: log: JS loading
JS: JSInterpreter init
```

In debug mode:

```
$ swift test -c debug | grep ^JS:
JS: JSInterpreter init
JS: log: JS loading
JS: debug: Debug log
```